### PR TITLE
Remove unneeded `template`

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -1,7 +1,3 @@
-<template>
-  <div></div>
-</template>
-
 <script>
 export default {
   props: {
@@ -26,6 +22,7 @@ export default {
         this.$emit("pressed", event.keyCode);
       }
     }
-  }
+  },
+  render: () => null
 };
 </script>


### PR DESCRIPTION
To save up resources while rendering, a simple empty comment will be rendered instead of `<div>`. This doesn't break events and props.