### PR TITLE
Add ability to preventDefault

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ components: {
 | ------- | ------ | ------- | --------------------------------- | ------------------------------------------------------------------------- |
 | keyCode | Number | null    | [see here](https://keycode.info/) | Key that should trigger the event. If _null_, any key will trigger event. |
 | event   | String | 'keyup' | _keydown_, _keypress_, _keyup_    |
+| preventDefault   | Boolean | false | _true_,_false_    | Prevent the default action of the event |
 
 # Events
 

--- a/src/index.vue
+++ b/src/index.vue
@@ -10,8 +10,7 @@ export default {
       default: "keyup"
     },
     preventDefault: {
-      type: Bolean,
-      default: null
+      type: Boolean
     }
   },
   mounted() {

--- a/src/index.vue
+++ b/src/index.vue
@@ -21,11 +21,10 @@ export default {
   },
   methods: {
     emitEvent(e) {
-      if (this.preventDefault) {
-          e.preventDefault();
-      }
-      
       if (event.keyCode === this.keyCode || !this.keyCode) {
+        if( this.preventDefault ){
+            e.preventDefault();
+        }
         this.$emit("pressed", event.keyCode);
       }
     }

--- a/src/index.vue
+++ b/src/index.vue
@@ -8,6 +8,10 @@ export default {
     event: {
       type: String,
       default: "keyup"
+    },
+    preventDefault: {
+      type: Bolean,
+      default: null
     }
   },
   mounted() {
@@ -17,7 +21,11 @@ export default {
     window.removeEventListener(this.event, this.emitEvent);
   },
   methods: {
-    emitEvent() {
+    emitEvent(e) {
+      if (this.preventDefault) {
+          e.preventDefault();
+      }
+      
       if (event.keyCode === this.keyCode || !this.keyCode) {
         this.$emit("pressed", event.keyCode);
       }


### PR DESCRIPTION
This PR adds the ability to pass a boolean value to Keypress to run the preventDefault method on the keyup event. This will allow for situations where you want to use this feature on longer pages with the up arrow or down arrow keys without allowing it to scroll.